### PR TITLE
Removing link that gave 404 error

### DIFF
--- a/_posts/R/2016-07-13-parallel-r-on-jupyterhub.md
+++ b/_posts/R/2016-07-13-parallel-r-on-jupyterhub.md
@@ -40,7 +40,7 @@ num_cores <- detectCores()
 cl <- makeCluster(num_cores)
 ```
 
-The parallel package contains functions that mirror the base R [lapply](http://www.inside-r.org/r-doc/base/sapply) function. The following example will calculate the square of each number in a sequence in parallel.
+The parallel package contains functions that mirror the base R `sapply` function. The following example will calculate the square of each number in a sequence in parallel.
 
 
 ```R


### PR DESCRIPTION
Removed a link that broke our build: https://travis-ci.org/earthlab/earthlab.github.io/builds/185559337