### PR TITLE
Removing colon from NEON description to fix double quote problem

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -21,7 +21,7 @@
   bio: ''
 - name: NEON Data Skills
   slug: neon-data-skills
-  bio: 'NEON Data Skills develops tutorials that support the use of NEON data. Check out their website: http://www.neondataskills.org'
+  bio: 'NEON Data Skills develops tutorials that support the use of NEON data. Check out their website at http://www.neondataskills.org'
 - name: Reproducible Science Curriculum Community
   slug: reproducible-science-curriculum-community
   bio: ''

--- a/org/author-bios.csv
+++ b/org/author-bios.csv
@@ -3,6 +3,6 @@ leah-wasser, Leah is the director of the Earth Analytics Education Initiative at
 matt-oakley, Matt worked with the Analytics Hub as an undergraduate intern in 2016 while pursuing his degree in computer science.
 max-joseph, Max is a data scientist with the Analytics Hub at Earth Lab and maintains this website.
 naupaka-zimmerman,
-neon-data-skills, NEON Data Skills develops tutorials that support the use of NEON data. Check out their website: http://www.neondataskills.org
+neon-data-skills, NEON Data Skills develops tutorials that support the use of NEON data. Check out their website at http://www.neondataskills.org
 reproducible-science-curriculum-community,
 zach-schira, Zach worked with the Analytics Hub as an undergraduate intern in 2016 and 2017 while pursuing his degree in aerospace engineering.

--- a/org/authors/neon-data-skills.md
+++ b/org/authors/neon-data-skills.md
@@ -5,5 +5,5 @@ permalink: /authors/neon-data-skills/
 title: 'NEON Data Skills'
 author_profile: false
 site-map: true
-bio: 'NEON Data Skills develops tutorials that support the use of NEON data. Check out their website: http://www.neondataskills.org'
+bio: 'NEON Data Skills develops tutorials that support the use of NEON data. Check out their website at http://www.neondataskills.org'
 ---


### PR DESCRIPTION
When the colon was present in the bio, the author validation code treats this as another field, leading to double quotes. Removing the colon seems to solve this problem. 