### PR TITLE
Use a development config file on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ _site/
 .Rhistory
 pdf/
 tutorials/
+_config-dev.yml
+

--- a/_data/topics.yml
+++ b/_data/topics.yml
@@ -7,7 +7,7 @@ open-science:
 social-science:
   subtopics: ['social-media']
 time-series:
-  subtopics: ['convert-date-time', 'epoch', 'julian-day', 'day-of-year']
+  subtopics: ['convert-date-time', 'epoch', 'julian-day', 'day-of-year', 'autoregressive']
 data-exploration-and-analysis:
   subtopics: ['data-visualization', 'text-mining', 'machine-learning']
 spatial-data-and-gis:

--- a/org/topics/time-series/autoregressive.md
+++ b/org/topics/time-series/autoregressive.md
@@ -1,0 +1,10 @@
+---
+layout: post-by-category
+title: 'Time Series - Autoregressive'
+permalink: /tags/time-series/autoregressive/
+comments: false
+author_profile: false
+is-main-topic: false
+topics:
+  time-series: autoregressive
+---

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -e # halt script on error
 
-bundle exec jekyll build
+# create a development _config.yml file and comment out url
+cp _config.yml _config-dev.yml
+sed -i -e 's/"http:\/\/earthdatascience.org"/#"http:\/\/earthdatascience.org"/g' _config-dev.yml
+
+# build the site with that url
+bundle exec jekyll build --config _config-dev.yml
 bundle exec htmlproofer ./_site
+
+# remove dev config file
+rm _config-dev.yml
 


### PR DESCRIPTION
Previously Travis CI was checking the live site when checking links.
By specifying a development config file (_config-dev.yml), perhaps Travis will check against the built version of the site, not the deployed version...
I opted to create this dev config file at build time so that we don't have to manually maintain two parallel config files.
This should just copy the actual _config.yml file, and replace the url with a commented out version.
Curious to see how Travis handles this!