### PR TITLE
Adding support for multiple subtopics

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -16,6 +16,9 @@
 - name: Megan Cattau
   slug: megan-cattau
   bio: ''
+- name: Mollie Buckland
+  slug: mollie-buckland
+  bio: ''
 - name: Naupaka Zimmerman
   slug: naupaka-zimmerman
   bio: ''

--- a/_data/topics.yml
+++ b/_data/topics.yml
@@ -15,7 +15,7 @@ spatial-data-and-gis:
 reproducible-science-and-programming:
   subtopics: ['RStudio', 'literate-expressive-programming','functions', 
               'r-studio', 'automate-science-workflows', 'git', 'markdown', 
-              'rmarkdown']
+              'rmarkdown', 'data-management']
 find-and-manage-data:
   subtopics: ['data-management', 'find-data', 'metadata']
 file-formats:

--- a/org/authors/mollie-buckland.md
+++ b/org/authors/mollie-buckland.md
@@ -1,0 +1,9 @@
+---
+layout: post-by-author
+author: Mollie Buckland
+permalink: /authors/mollie-buckland/
+title: 'Mollie Buckland'
+author_profile: false
+site-map: true
+bio: ''
+---


### PR DESCRIPTION
Now when a post has 2+ subtopics associated with one topic, our make workflow will pick this up and generate any necessary md files.

Additionally, on an unrelated note, this commit adds Mollie's bio as a consequence of running make.