### PR TITLE
Fixing assumptions about yaml headers

### DIFF
--- a/_data/topics.yml
+++ b/_data/topics.yml
@@ -15,7 +15,8 @@ spatial-data-and-gis:
 reproducible-science-and-programming:
   subtopics: ['RStudio', 'literate-expressive-programming','functions',
               'r-studio', 'automate-science-workflows', 'git', 'markdown',
-              'rmarkdown', 'data-management', 'version-control']
+              'rmarkdown', 'data-management', 'version-control', 
+              'literate expressive programming', 'python']
 find-and-manage-data:
   subtopics: ['data-management', 'find-data', 'metadata', 'missing-data-nan', 'apis']
 file-formats:

--- a/processing-code/helpers.R
+++ b/processing-code/helpers.R
@@ -39,6 +39,9 @@ yaml2df <- function(file, field) {
   #   - data frame with file, field, and value (one row per element)
   first_n_lines <- read_lines(file, n_max = 100) # should contain frontmatter
   delims <- which(grepl(pattern = "---", x = first_n_lines))
+  if (length(delims) > 1) {
+    delims <- delims[2]
+  }
   
   null_result <- data.frame(value = NULL, slug = NULL)
   
@@ -46,7 +49,7 @@ yaml2df <- function(file, field) {
     # file does not contain yaml
     return(null_result)
   }
-  yaml_list <- first_n_lines[(delims[1] + 1):(delims[2] - 1)] %>%
+  yaml_list <- first_n_lines[1:(delims - 1)] %>%
     paste(collapse = "\n") %>%
     yaml.load()
   
@@ -83,6 +86,7 @@ yaml2df <- function(file, field) {
   df %>%
     mutate(file = file, field = field)
 }
+
 
 
 firstup <- function(x) {


### PR DESCRIPTION
Solves #503

This bug had to do with assumptions about how the lessons began. We assumed all lessons started with: 

```
---
yaml stuff
---

lesson stuff
```

But this wasn't always the case. Sometimes the first `---` were missing.