### PR TITLE
Add Ally Faller to authors for blog post

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,3 +1,6 @@
+- name: Ally Faller
+  slug: ally-faller
+  bio: ''
 - name: Bryce Mecum
   slug: bryce-mecum
   bio: 'Bryce is a Scientific Software Engineer at the National Center for Ecological Analysis and Synthesis working remotely from Juneau'

--- a/org/authors/ally-faller.md
+++ b/org/authors/ally-faller.md
@@ -1,0 +1,9 @@
+---
+layout: post-by-author
+author: Ally Faller
+permalink: /authors/ally-faller/
+title: 'Ally Faller'
+author_profile: false
+site-map: true
+bio: ''
+---


### PR DESCRIPTION
@lwasser This PR adds Ally Faller to authors.yml and the authors directory as ```org/authors/ally-faller.md```. 