### PR TITLE
Fix duplicated order

### DIFF
--- a/_posts/courses/earth-analytics-python/02-intro-to-lidar-and-raster/interactive-maps/static-basemaps.md
+++ b/_posts/courses/earth-analytics-python/02-intro-to-lidar-and-raster/interactive-maps/static-basemaps.md
@@ -14,7 +14,7 @@ sidebar:
 author_profile: false
 comments: true
 course: "earth-analytics-python"
-order: 2
+order: 4
 topics:
   data-exploration-and-analysis: ['data-visualization']
   spatial-data-and-gis:


### PR DESCRIPTION
Needed for proper import by Taoti - if this file is outdated/deprecated not needed.
Of the four lessons in this class grouping, 2 of them had an 'order' value of 2 - as well as impairing import for us, I see that this file isn't currently being rendered by jekyll; if it should be ignored, just let us know, thanks.
Nick Wilde