### PR TITLE
add  auto generated TOC for all textbooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pdf/
 _config-dev.yml
 _config.yml
 Gemfile.lock
+.idea/workspace.xml

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _config-dev.yml
 _config.yml
 Gemfile.lock
 .idea/workspace.xml
+.idea/

--- a/_includes/textbook-section-toc.html
+++ b/_includes/textbook-section-toc.html
@@ -1,9 +1,11 @@
 
 {% assign course_posts = site.posts | where:"course", page.course %}
-{% assign sorted_posts = course_posts | sort:"order" %}
+{% assign section_posts = course_posts | where: "week", page.week %}
+{% assign sorted_posts = section_posts | sort:"order" %}
+
 {% assign chapters = sorted_posts | where:"order", 1 %}
 {% assign sorted_chapters = chapters | sort:"class-order" %}
-{% assign session_weeks = course_posts | where:"module-type", 'session' %}
+{% assign session_weeks = section_posts | where:"module-type", 'session' %}
 {% assign sorted_session_weeks = session_weeks | sort:'week' %}
 
 

--- a/_includes/textbook-toc.html
+++ b/_includes/textbook-toc.html
@@ -7,7 +7,7 @@
 {% assign sorted_session_weeks = session_weeks | sort:'week' %}
 
 {% for post in sorted_session_weeks %}
-<div markdown="1">
+<div>
 <table>
 <thead>
     <tr><th><a href="{{ site.url }}{{ post.permalink }}"> Section{% if post.nav-title %}{{ post.week }}. {{ post.nav-title }} {% else %} {{ post.week }}. {{ post.title }}{% endif %}</a> </th></tr>

--- a/_includes/textbook-toc.html
+++ b/_includes/textbook-toc.html
@@ -9,17 +9,25 @@
 {% for post in sorted_session_weeks %}
 <div>
 <table>
-<thead>
-    <tr><th><a href="{{ site.url }}{{ post.permalink }}"> Section{% if post.nav-title %}{{ post.week }}. {{ post.nav-title }} {% else %} {{ post.week }}. {{ post.title }}{% endif %}</a> </th></tr>
-</thead>
-<tbody>
-      <!-- list the chapters for each section -->
-      {% for chapter in sorted_chapters %}
+    <thead>
+        <tr>
+            <th>
+                <a href="{{ site.url }}{{ post.permalink }}"> Section{% if post.nav-title %}{{ post.week }}. {{ post.nav-title }} {% else %} {{ post.week }}. {{ post.title }}{% endif %}</a>
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+    <!-- list the chapters for each section -->
+    {% for chapter in sorted_chapters %}
         {% if chapter.week == post.week %}
-    <tr><td><a href="{{ site.url }}{{ chapter.permalink }}">Chapter {{ chapter.class-order }}: {{ chapter.module-nav-title }} </a></td></tr>
+        <tr>
+            <td>
+                <a href="{{ site.url }}{{ chapter.permalink }}">Chapter {{ chapter.class-order }}: {{ chapter.module-nav-title }} </a>
+            </td>
+        </tr>
         {% endif %}
-      {% endfor %}
-</tbody>
+    {% endfor %}
+    </tbody>
 </table>
 </div>
 

--- a/_includes/textbook-toc.html
+++ b/_includes/textbook-toc.html
@@ -1,0 +1,26 @@
+
+{% assign course_posts = site.posts | where:"course", page.course %}
+{% assign sorted_posts = course_posts | sort:"order" %}
+{% assign chapters = sorted_posts | where:"order", 1 %}
+{% assign sorted_chapters = chapters | sort:"class-order" %}
+{% assign session_weeks = course_posts | where:"module-type", 'session' %}
+{% assign sorted_session_weeks = session_weeks | sort:'week' %}
+
+{% for post in sorted_session_weeks %}
+<div markdown="1">
+<table>
+<thead>
+    <tr><th><a href="{{ site.url }}{{ post.permalink }}"> Section{% if post.nav-title %}{{ post.week }}. {{ post.nav-title }} {% else %} {{ post.week }}. {{ post.title }}{% endif %}</a> </th></tr>
+</thead>
+<tbody>
+      <!-- list the chapters for each section -->
+      {% for chapter in sorted_chapters %}
+        {% if chapter.week == post.week %}
+    <tr><td><a href="{{ site.url }}{{ chapter.permalink }}">Chapter {{ chapter.class-order }}: {{ chapter.module-nav-title }} </a></td></tr>
+        {% endif %}
+      {% endfor %}
+</tbody>
+</table>
+</div>
+
+{% endfor %}


### PR DESCRIPTION
this addresses #776 

essentially this adds an automagically generated linkable table of contents to a textbook. to use, add

`{% include textbook-toc.html %}`

or

`{% include textbook-section-toc.html %}` for a section TOC

anywhere you'd like the TOC to be placed on a markdown page! It will populate a TOC for the entire module / course etc but it's really textbook based as it says chapter and section. i could potentially add variables to it int he future..

@jlpalomino please test this out and let me know if it works. 