### PR TITLE
Deprecate all ea python content

### DIFF
--- a/_includes/sidebar_class_navigation_week.html
+++ b/_includes/sidebar_class_navigation_week.html
@@ -72,7 +72,7 @@
                 {% if post.url == page.url %}
                     <li>  <a href="{{ site.url }}{{ post.permalink }}" class='active'> SECTION {{ post.week }}<br><!--<i class="fa fa-folder-open" aria-hidden="true"></i> -->
                          {% if post.nav-title %} {{ post.nav-title | upcase }} {% else %} {{ post.title | upcase }}{% endif %}</a></li>
-                {% else %} 
+                {% else %}
                     <li class='active-section'> <a href="{{ site.url }}{{ post.permalink }}"><i class="fa fa-folder-open" aria-hidden="true"></i>
                     {% if post.nav-title %}{{ post.chapter }} {{ post.week }}. {{ post.nav-title | upcase }} {% else %} {{ post.week }}. {{ post.title | upcase }}{% endif %}</a></li>
 
@@ -112,7 +112,7 @@
        </ul>
         {% endfor %}
 
-        {% if lesson_count == 0 %} <li>There are no lessons for this week. </li> {% endif %}
+        {% if lesson_count == 0 %} <li>We have moved our lessons to a shiny new textbook series to make content easier to find! </li> {% endif %}
       </ul>
 
       <!-- BEGIN Learn how to lessons -->

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -57,16 +57,33 @@ layout: default
           <!-- BEGIN: insert a welcome to the module block on pages that are part of a module set -->
 
           <!-- END: insert welcome block -->
+
           {% if page.title %}
-            <h1 class="page__title" itemprop="headline">
+
+              {% if page.course == "earth-analytics-python" %}
+                  <div class="notice--warning header" markdown="1">
+                  <h1 class="page__title" itemprop="headline"> <i class="fa fa-6 fa-exclamation-circle" aria-hidden="true"></i> THIS CONTENT IS MOVING! {{ page.module-title }} </h1>
+                  <p>We are moving all of our course lessons to textbook series. All of the same
+                  content will be improved and available by the end of Spring 2020. While these pages will automagically redirect,
+                  you can also visit the links below to check out our new content!
+                  </p>
+                  <ul>
+                      <li><a href="https://www.earthdatascience.org/courses/intro-to-earth-data-science/">Introduction to Earth Analytics Textbook</a></li>
+                      <li><a href="https://www.earthdatascience.org/courses/use-data-open-source-python/">Intermediate Earth Analytics Textbook</a></li>
+                      <li><a href="https://www.earthdatascience.org/courses/scientists-guide-to-plotting-data-in-python/">Earth Analytics Plotting Data Textbook</a></li>
+                  </ul>
+                  </div>
+              {% endif %}
             {% if page.deprecated %}
-                {% if page.order %}<i class="fa fa-6 fa-exclamation-circle" aria-hidden="true"></i> DEPRECATED / MOVED Lesson  {% endif %}
+                <h1 class="page__title" itemprop="headline">{% if page.order %}<i class="fa fa-6 fa-exclamation-circle" aria-hidden="true"></i> DEPRECATED / MOVED Lesson  {% endif %}</h1>
             {% else %}
+                <h1 class="page__title" itemprop="headline">
                 {% if page.order %}Lesson {{ page.order }}. {% endif %}
                 {% if page.header1 %}{{ page.header1 | markdownify | remove: "<p>" | remove: "</p>" }}{% else %} {{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}{% endif %}
                 {% if page.module %} {{ page.module | replace: '-', ' ' | capitalize }} {{ page.module-type | capitalize }} {% endif %}
+                </h1>
             {% endif %}
-            </h1>
+
           {% endif %}
 
           {% if page.authors %}

--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -63,9 +63,11 @@ layout: default
               {% if page.course == "earth-analytics-python" %}
                   <div class="notice--warning header" markdown="1">
                   <h1 class="page__title" itemprop="headline"> <i class="fa fa-6 fa-exclamation-circle" aria-hidden="true"></i> THIS CONTENT IS MOVING! {{ page.module-title }} </h1>
-                  <p>We are moving all of our course lessons to textbook series. All of the same
+                  <p>We are moving our course lessons to an improved textbook series. All of the same
                   content will be improved and available by the end of Spring 2020. While these pages will automagically redirect,
                   you can also visit the links below to check out our new content!
+
+                  Our course landing pages with associated readings and assignments will stay here so you can continue to follow along with our courses!
                   </p>
                   <ul>
                       <li><a href="https://www.earthdatascience.org/courses/intro-to-earth-data-science/">Introduction to Earth Analytics Textbook</a></li>


### PR DESCRIPTION
This just provides a message at the top of the page that all of the content is moving. 
I probably should avoid this on landing pages but can work on that in a future pr too.