### PR TITLE
Make Lessons open so they can be used in ANY classroom as intended

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,19 +1,19 @@
 ### Instructional Material
 
 All Earth Lab instructional material is made available under
-the [Creative Commons Attribution NonCommercial No Derivatives license](https://creativecommons.org/licenses/by-nc-nd/4.0/).
+the [Creative Commons Attribution ShareALike](https://creativecommons.org/licenses/by-sa/4.0/).
 
-You are free to use these materials in a classroom setting where there is no monetary exchange involved. 
+You are free to use these materials in a classroom setting.
 
 If you use these materials following the license - please also provide attribution as follows:
 
-* **Attribution**---You must attribute the work using "Copyright (c)
-  Earth Lab" (but not in any way that suggests that we
-  endorse you or your use of the work). You must
-  also include a hyperlink to https://www.earthdatascience.org.
+* **Attribution**---You must attribute the work using "Lessons adapted from
+  materials developed by Earth Lab" (but not in any way that suggests that we
+  endorse you or your use of the work). Please also include a hyperlink
+  to https://www.earthdatascience.org.
 
-* **NonCommercial**--You may not use the material for commercial purposes or where there is a monetary exchange involved.
-
+* **ShareALike**---You must apply the same license to any content that you create
+  that is derived from this material.
 
 ### Software
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
     <li>
       <strong>&copy; {{ site.time | date: '%Y' }} Earth Lab -
       <a href="{{ site.url }}{{ site.baseurl }}/license"> All materials on this site
-        are subject to the CC BY-NC-ND 4.0 License. </a>
+        are subject to the CC BY-SA 4.0 License. </a>
       </strong>
     </li>
   </ul>

--- a/_includes/license.html
+++ b/_includes/license.html
@@ -1,12 +1,12 @@
 {% for course in site.data.doi_license %}
   {% if page.course == course.name %}
      The {{ course.name | replace:'-',' ' | capitalize }} course is subject to the
-     <a href="{{ site.url }}{{ site.baseurl }}/license" target="_blank">CC BY-NC-ND 4.0 License </a>.
+     <a href="{{ site.url }}{{ site.baseurl }}/license" target="_blank">CC BY-SA 4.0 License </a>.
       Citation DOI: <a href="{{ course.doi }}" target="_blank"> {{ course.doi }}</a>
   {% endif %}
   {% if page.module == course.name %}
      The {{ course.module | replace:'-',' ' | capitalize }} workshop is subject to the
-     <a href="{{ site.url }}{{ site.baseurl }}/license" target="_blank">CC BY-NC-ND 4.0 License </a>.
+     <a href="{{ site.url }}{{ site.baseurl }}/license" target="_blank">CC BY-SA 4.0 License </a>.
       Citation DOI: <a href="{{ course.doi }}" target="_blank"> {{ course.doi }}</a>
   {% endif %}
 {% endfor %}

--- a/_pages/license.md
+++ b/_pages/license.md
@@ -10,19 +10,19 @@ permalink: /license/
 ### Instructional Material
 
 All Earth Lab instructional material is made available under
-the [Creative Commons Attribution NonCommercial No Derivatives license](https://creativecommons.org/licenses/by-nc-nd/4.0/).
+the [Creative Commons Attribution ShareALike](https://creativecommons.org/licenses/by-sa/4.0/).
 
-You are free to use these materials in a classroom setting where there is no monetary exchange involved. 
+You are free to use these materials in a classroom setting.
 
 If you use these materials following the license - please also provide attribution as follows:
 
-* **Attribution**---You must attribute the work using "Copyright (c)
-  Earth Lab" (but not in any way that suggests that we
-  endorse you or your use of the work). You must
-  also include a hyperlink to https://www.earthdatascience.org.
+* **Attribution**---You must attribute the work using "Lessons adapted from
+  materials developed by Earth Lab" (but not in any way that suggests that we
+  endorse you or your use of the work). Please also include a hyperlink
+  to https://www.earthdatascience.org.
 
-* **NonCommercial**--You may not use the material for commercial purposes or where there is a monetary exchange involved.
-
+* **ShareALike**---You must apply the same license to any content that you create
+  that is derived from this material.
 
 ### Software
 


### PR DESCRIPTION
This pr closes #1032 
Essentially i've had many people contact me who want to use this material in their courses. The ND and NC clauses prevents them from 1. adapting it to their needs and 2. because there is technically a monetary exchange when taking a course, they can't use it that way either. it's all unclear.

The funding from NSF included making the bootcamp textbook and our content developed available and open and so this PR will ensure that people can use the content in their courses!